### PR TITLE
Allow non-square images

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -475,14 +475,14 @@ class GaussianDiffusion(nn.Module):
         self.channels = self.model.channels
         self.self_condition = self.model.self_condition
 
-        # make image size a tuple of (width, height)
+        # make image size a tuple of (height, width)
         if isinstance(image_size, int):
             self.image_size = (image_size, image_size)
         elif isinstance(image_size, tuple):
-            assert len(image_size) == 2, 'image size must be a tuple of (width, height)'
+            assert len(image_size) == 2, 'image size must be a tuple of (height, width)'
             self.image_size = image_size
         else:
-            raise TypeError('image size must be an int or a tuple of (width, height)')
+            raise TypeError('image size must be an int or a tuple of (height, width)')
 
         self.objective = objective
 

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -5,7 +5,7 @@ from random import random
 from functools import partial
 from collections import namedtuple
 from multiprocessing import cpu_count
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 from torch import nn, einsum
@@ -454,7 +454,7 @@ class GaussianDiffusion(nn.Module):
         self,
         model,
         *,
-        image_size: int | Tuple[int, int],  # (height, width)
+        image_size: Union[int, Tuple[int, int]],  # (height, width)
         timesteps = 1000,
         sampling_timesteps = None,
         objective = 'pred_v',

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -5,6 +5,7 @@ from random import random
 from functools import partial
 from collections import namedtuple
 from multiprocessing import cpu_count
+from typing import Tuple
 
 import torch
 from torch import nn, einsum
@@ -453,7 +454,7 @@ class GaussianDiffusion(nn.Module):
         self,
         model,
         *,
-        image_size,
+        image_size: int | Tuple[int, int],  # (height, width)
         timesteps = 1000,
         sampling_timesteps = None,
         objective = 'pred_v',

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -474,7 +474,14 @@ class GaussianDiffusion(nn.Module):
         self.channels = self.model.channels
         self.self_condition = self.model.self_condition
 
-        self.image_size = image_size
+        # make image size a tuple of (width, height)
+        if isinstance(image_size, int):
+            self.image_size = (image_size, image_size)
+        elif isinstance(image_size, tuple):
+            assert len(image_size) == 2, 'image size must be a tuple of (width, height)'
+            self.image_size = image_size
+        else:
+            raise TypeError('image size must be an int or a tuple of (width, height)')
 
         self.objective = objective
 
@@ -709,7 +716,7 @@ class GaussianDiffusion(nn.Module):
     def sample(self, batch_size = 16, return_all_timesteps = False):
         image_size, channels = self.image_size, self.channels
         sample_fn = self.p_sample_loop if not self.is_ddim_sampling else self.ddim_sample
-        return sample_fn((batch_size, channels, image_size, image_size), return_all_timesteps = return_all_timesteps)
+        return sample_fn((batch_size, channels, image_size[0], image_size[1]), return_all_timesteps = return_all_timesteps)
 
     @torch.inference_mode()
     def interpolate(self, x1, x2, t = None, lam = 0.5):
@@ -789,7 +796,7 @@ class GaussianDiffusion(nn.Module):
 
     def forward(self, img, *args, **kwargs):
         b, c, h, w, device, img_size, = *img.shape, img.device, self.image_size
-        assert h == img_size and w == img_size, f'height and width of image must be {img_size}'
+        assert h == img_size[0] and w == img_size[1], f'height and width of image must be {img_size}'
         t = torch.randint(0, self.num_timesteps, (b,), device=device).long()
 
         img = self.normalize(img)


### PR DESCRIPTION
Currently, only square images are allowed where `image_size` is `int`. This change allows for non-square where `image_size` can be (height, width).

This is based on the following conversation: https://github.com/lucidrains/denoising-diffusion-pytorch/issues/183